### PR TITLE
Speedup add missing coin prices

### DIFF
--- a/tracker/coin_price.py
+++ b/tracker/coin_price.py
@@ -1,19 +1,18 @@
-import time
 from typing import List
 
-import requests
-
 from tracker import db
-from tracker.external_api.coinbase_api import cb_get_coin_price, CoinbaseInvalidBaseCurrencyError
+from tracker.external_api.coinbase_api import (
+    cb_get_coin_price,
+    CoinbaseInvalidBaseCurrencyError,
+)
 from tracker.external_api.coingecko_api import cg_get_coin_price
-from tracker.utils import log_info, EUR_FAKE_CG_ID, EUR_TICKER
+from tracker.utils import log_info
 
 
 def add_missing_coin_prices() -> None:
     """Add missing coin prices, after getting valuation for each day"""
 
     missing_coin_prices = get_missing_coin_prices()
-    exit(0)
     if missing_coin_prices:
         # save in db
         for cp in missing_coin_prices:
@@ -32,7 +31,7 @@ def add_missing_coin_prices() -> None:
 def get_missing_coin_prices() -> List[dict]:
     """Get missing coin prices, using CoinGecko APIs
 
-    :return: [ { date_, coin_id:_, coin_eur:_ }, ... ]
+    :return: [ { date_, coin_id:_, coin_ticker:_, coin_eur:_ }, ... ]
     """
 
     # get missing date-coin
@@ -47,29 +46,22 @@ def get_missing_coin_prices() -> List[dict]:
     # try untill it fails (max req in a minute)
     for mp in missing_prices:
         # print("\ndoing: ", mp)
+        date_ = mp["date"]
         coin_ticker = coin_id_to_ticker[mp["coin_id"]]
-        if coin_ticker == EUR_TICKER:
-            coin_eur = 1.00
-        else:
-            try:
-                coin_eur = cb_get_coin_price(mp["date"], coin_ticker)
-            except CoinbaseInvalidBaseCurrencyError as e:
-                print(f"Handling {e} using Coingecko APIs...")
-                # TODO: prendi usando coingecko
-
-            msg_e = f"Failed to get {coin_ticker} price (in EUR) for {mp['date']}"
-            assert coin_eur, msg_e
+        coingecko_id = coin_id_to_coingecko_id[mp["coin_id"]]
+        try:
+            coin_eur = cb_get_coin_price(date_, coin_ticker)
+        except CoinbaseInvalidBaseCurrencyError as e:
+            # print(f"Handling exc ({e}) using Coingecko APIs...")
+            coin_eur = cg_get_coin_price(date_, coin_ticker, coingecko_id)
 
         cp = {
-            "date": mp["date"],
+            "date": date_,
             "coin_id": mp["coin_id"],
             "coin_ticker": coin_ticker,
             "coin_eur": coin_eur,
         }
-        print(f"cp: {cp}")
+        # print(f"cp: {cp}")
         coin_prices.append(cp)
 
     return coin_prices
-
-
-# print(get_missing_coin_prices())

--- a/tracker/coin_price.py
+++ b/tracker/coin_price.py
@@ -4,14 +4,16 @@ from typing import List
 import requests
 
 from tracker import db
+from tracker.external_api.coinbase_api import cb_get_coin_price, CoinbaseInvalidBaseCurrencyError
 from tracker.external_api.coingecko_api import cg_get_coin_price
-from tracker.utils import log_info, EUR_FAKE_CG_ID
+from tracker.utils import log_info, EUR_FAKE_CG_ID, EUR_TICKER
 
 
 def add_missing_coin_prices() -> None:
     """Add missing coin prices, after getting valuation for each day"""
 
     missing_coin_prices = get_missing_coin_prices()
+    exit(0)
     if missing_coin_prices:
         # save in db
         for cp in missing_coin_prices:
@@ -38,32 +40,36 @@ def get_missing_coin_prices() -> List[dict]:
     # print(f"missing_prices: {missing_prices}")
 
     coin_id_to_coingecko_id = {c["id"]: c["coingecko_id"] for c in db.coin.select()}
+    coin_id_to_ticker = {c["id"]: c["symbol"] for c in db.coin.select()}
 
     coin_prices: List[dict] = []
 
     # try untill it fails (max req in a minute)
     for mp in missing_prices:
         # print("\ndoing: ", mp)
-        cp: dict = {}
-        t = 10
-        while not cp:
+        coin_ticker = coin_id_to_ticker[mp["coin_id"]]
+        if coin_ticker == EUR_TICKER:
+            coin_eur = 1.00
+        else:
             try:
-                coingecko_id = coin_id_to_coingecko_id[mp["coin_id"]]
-                if coingecko_id == EUR_FAKE_CG_ID:
-                    cp = {
-                        "date": mp["date"],
-                        "coin_id": mp["coin_id"],
-                        "coin_eur": 1.00,
-                    }
-                else:
-                    cp = cg_get_coin_price(mp["coin_id"], coingecko_id, mp["date"])
-            # exceded 50 reqs in a minute
-            except (requests.exceptions.HTTPError, ValueError) as e:
-                # print(f"caught {e} ...")
-                msg = f"Got {len(coin_prices)}/{len(missing_prices)} prices, waiting {t} secs ..."
-                print(msg)
-                time.sleep(t)
-                t += 10
+                coin_eur = cb_get_coin_price(mp["date"], coin_ticker)
+            except CoinbaseInvalidBaseCurrencyError as e:
+                print(f"Handling {e} using Coingecko APIs...")
+                # TODO: prendi usando coingecko
+
+            msg_e = f"Failed to get {coin_ticker} price (in EUR) for {mp['date']}"
+            assert coin_eur, msg_e
+
+        cp = {
+            "date": mp["date"],
+            "coin_id": mp["coin_id"],
+            "coin_ticker": coin_ticker,
+            "coin_eur": coin_eur,
+        }
+        print(f"cp: {cp}")
         coin_prices.append(cp)
 
     return coin_prices
+
+
+# print(get_missing_coin_prices())

--- a/tracker/db/coin.py
+++ b/tracker/db/coin.py
@@ -43,6 +43,7 @@ def get_symbol_by_id(coin_id: int) -> Optional[str]:
 
 
 def select() -> List[dict]:
+    """:return: [ {  } ]"""
     conn = get_conn()
     curr = conn.cursor()
 

--- a/tracker/external_api/coinbase_api.py
+++ b/tracker/external_api/coinbase_api.py
@@ -1,8 +1,10 @@
 from datetime import date
-from decimal import Decimal, InvalidOperation
-from typing import Optional, Union
+from decimal import Decimal
+from typing import Union
 
 import requests
+
+from tracker.utils import EUR_TICKER
 
 COINBASE_API = "https://api.coinbase.com/v2/"
 ATTEMPTS = 3
@@ -11,21 +13,23 @@ ATTEMPTS = 3
 class CoinbaseInvalidBaseCurrencyError(Exception):
     pass
 
+
 class CoinbaseUnexpectedError(Exception):
     pass
 
 
-def cb_get_coin_price(date_: Union[str, date], coin_type: str) -> Optional[Decimal]:
+def cb_get_coin_price(date_: Union[str, date], coin_type: str) -> float:
     """Get the price of coin on specified date
 
     :return: coin_eur
     """
+    # eur
+    if coin_type == EUR_TICKER:
+        return 1.00
 
+    # other coins
     endpoint = f"prices/{coin_type}-EUR/spot?date={date_}"
     url = COINBASE_API + endpoint
-    print("\n", url)
-    # response = requests.get(url).json()
-    # exch_rate = Decimal(response["data"]["amount"])
 
     coin_eur = None
     for _ in range(ATTEMPTS):
@@ -33,8 +37,13 @@ def cb_get_coin_price(date_: Union[str, date], coin_type: str) -> Optional[Decim
             response = requests.get(url).json()
 
             if "errors" in response:
-                if "message" in response["errors"][0] and response["errors"][0]["message"] == "Invalid base currency":
-                    raise CoinbaseInvalidBaseCurrencyError(f"Invalid base currency for CoinBase: {coin_type} (url={url}, response={response})")
+                if (
+                    "message" in response["errors"][0]
+                    and response["errors"][0]["message"] == "Invalid base currency"
+                ):
+                    raise CoinbaseInvalidBaseCurrencyError(
+                        f"Invalid base currency for CoinBase: {coin_type} (url={url}, response={response})"
+                    )
                 raise CoinbaseUnexpectedError(f"url={url}, response={response}")
 
             exch_rate = Decimal(response["data"]["amount"])
@@ -46,4 +55,6 @@ def cb_get_coin_price(date_: Union[str, date], coin_type: str) -> Optional[Decim
             coin_eur = exch_rate
             break
 
-    return round(coin_eur, 2) if coin_eur else None
+    msg_e = f"Failed to get {coin_type} price (in EUR) for {date_} with coinbase"
+    assert coin_eur, msg_e
+    return round(float(coin_eur), 2)

--- a/tracker/external_api/coinbase_api.py
+++ b/tracker/external_api/coinbase_api.py
@@ -1,0 +1,49 @@
+from datetime import date
+from decimal import Decimal, InvalidOperation
+from typing import Optional, Union
+
+import requests
+
+COINBASE_API = "https://api.coinbase.com/v2/"
+ATTEMPTS = 3
+
+
+class CoinbaseInvalidBaseCurrencyError(Exception):
+    pass
+
+class CoinbaseUnexpectedError(Exception):
+    pass
+
+
+def cb_get_coin_price(date_: Union[str, date], coin_type: str) -> Optional[Decimal]:
+    """Get the price of coin on specified date
+
+    :return: coin_eur
+    """
+
+    endpoint = f"prices/{coin_type}-EUR/spot?date={date_}"
+    url = COINBASE_API + endpoint
+    print("\n", url)
+    # response = requests.get(url).json()
+    # exch_rate = Decimal(response["data"]["amount"])
+
+    coin_eur = None
+    for _ in range(ATTEMPTS):
+        try:
+            response = requests.get(url).json()
+
+            if "errors" in response:
+                if "message" in response["errors"][0] and response["errors"][0]["message"] == "Invalid base currency":
+                    raise CoinbaseInvalidBaseCurrencyError(f"Invalid base currency for CoinBase: {coin_type} (url={url}, response={response})")
+                raise CoinbaseUnexpectedError(f"url={url}, response={response}")
+
+            exch_rate = Decimal(response["data"]["amount"])
+
+        except TimeoutError:
+            continue
+
+        if exch_rate != 0:
+            coin_eur = exch_rate
+            break
+
+    return round(coin_eur, 2) if coin_eur else None

--- a/tracker/external_api/coingecko_api.py
+++ b/tracker/external_api/coingecko_api.py
@@ -18,8 +18,6 @@ def cg_get_coin_price(coin_id: int, coingecko_id: str, date_: date) -> dict:
         id=coingecko_id, date=date_.strftime("%d-%m-%Y")
     )
 
-    return {
-        "date": date_,
-        "coin_id": coin_id,
-        "coin_eur": round(coin_history["market_data"]["current_price"]["eur"], 2),
-    }
+    # TODO: gestisci qua il timeout se chiedo ma ho fatto trppe richieste
+
+    return round(coin_history["market_data"]["current_price"]["eur"], 2)

--- a/tracker/external_api/coingecko_api.py
+++ b/tracker/external_api/coingecko_api.py
@@ -1,23 +1,55 @@
 # https://www.coingecko.com/en/api/documentation
 # NOTE: max 50 requests per minute
 
+import time
 from datetime import date
 
+import requests
 from pycoingecko import CoinGeckoAPI  # type: ignore
 
-cg = CoinGeckoAPI()
+from tracker.utils import EUR_FAKE_CG_ID
+
+COINGECKO_MAX_WAIT_TIME = 61
 
 
-def cg_get_coin_price(coin_id: int, coingecko_id: str, date_: date) -> dict:
+class CoingeckoMaxWaitTimeError(Exception):
+    pass
+
+
+class CoinbaseUnexpectedError(Exception):
+    pass
+
+
+def cg_get_coin_price(date_: date, coin_type: str, coingecko_id: str) -> float:
     """Get the price of coin on specified date
 
-    :return: { date:_, coin_id:_, coin_eur:_ }
+    :return: coin_eur
     """
+    # eur
+    if coingecko_id == EUR_FAKE_CG_ID:
+        return 1.00
 
-    coin_history = cg.get_coin_history_by_id(
-        id=coingecko_id, date=date_.strftime("%d-%m-%Y")
-    )
+    # other coins
+    cg = CoinGeckoAPI()
 
-    # TODO: gestisci qua il timeout se chiedo ma ho fatto trppe richieste
+    coin_eur = None
+    t = 10
+    while not coin_eur:
+        try:
+            coin_history = cg.get_coin_history_by_id(
+                coingecko_id, date_.strftime("%d-%m-%Y")
+            )
+            coin_eur = coin_history["market_data"]["current_price"]["eur"]
+        # exceded 50 reqs in a minute
+        except (requests.exceptions.HTTPError, ValueError) as e:
+            if t >= COINGECKO_MAX_WAIT_TIME:
+                msg_e = f"Reached max waiting time ({t}s)"
+                raise CoingeckoMaxWaitTimeError(msg_e)
+            print(f"caught {e} ...")
+            print(f"Waiting {t}s ...")
+            time.sleep(t)
+            t += 10
 
-    return round(coin_history["market_data"]["current_price"]["eur"], 2)
+    msg_e = f"Failed to get {coin_type} price (in EUR) for {date_} with coingecko"
+    assert coin_eur, msg_e
+    return round(float(coin_eur), 2)


### PR DESCRIPTION
- replacing coingecko APIs with coinbase, to speedup price getting
- handle BETH (or other coins not supported by coinbase) with coingecko